### PR TITLE
Fix location tracking

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,8 +3,6 @@ name: Spotless Check
 on:
   push:
     branches: ["**"]
-  pull_request:
-    branches: ["**"]
 
 jobs:
   # Run spotless check first

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
@@ -40,6 +42,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:

--- a/common/src/main/java/com/fischl/wynnrunner/mixin/LootrunModelMixin.java
+++ b/common/src/main/java/com/fischl/wynnrunner/mixin/LootrunModelMixin.java
@@ -19,6 +19,7 @@ import com.wynntils.mc.extension.EntityExtension;
 import com.wynntils.models.beacons.type.Beacon;
 import com.wynntils.models.lootrun.LootrunModel;
 import com.wynntils.models.lootrun.beacons.LootrunBeaconKind;
+import com.wynntils.models.lootrun.event.LootrunBeaconSelectedEvent;
 import com.wynntils.models.lootrun.type.LootrunLocation;
 import com.wynntils.models.lootrun.type.LootrunningState;
 import com.wynntils.models.lootrun.type.MissionType;
@@ -188,18 +189,6 @@ public abstract class LootrunModelMixin extends Model {
             lootrunDataHandler.save(false);
             return;
         }
-
-        Beacon closestBeacon = getClosestBeacon();
-        if (oldState == LootrunningState.CHOOSING_BEACON
-                && newState == LootrunningState.IN_TASK
-                && closestBeacon != null
-                && closestBeacon.beaconKind() instanceof LootrunBeaconKind color) {
-            lootrunDataHandler.getCurrentChallenge().setBeaconTaken(color);
-            var prediction = beacons.get(closestBeacon.beaconKind());
-            if (prediction != null && prediction.taskLocation() != null) {
-                lootrunDataHandler.getCurrentChallenge().setLocation(prediction.taskLocation());
-            }
-        }
     }
 
     @Inject(method = "challengeCompleted", at = @At("TAIL"))
@@ -287,6 +276,21 @@ public abstract class LootrunModelMixin extends Model {
             lastLoadedCharacterId = id;
         } catch (Throwable t) {
             Wynnrunner.error("Error in lootrun tick poller: " + t);
+        }
+    }
+
+    @Unique
+    @SubscribeEvent
+    public void onLootrunBeaconSelected(LootrunBeaconSelectedEvent event) {
+        lootrunDataHandler
+                .getCurrentChallenge()
+                .setBeaconTaken(LootrunBeaconKind.fromColor(
+                        event.getBeacon().beaconKind().getCustomColor()));
+        if (event.getTaskLocation() != null) {
+            lootrunDataHandler.getCurrentChallenge().setLocation(event.getTaskLocation());
+        } else {
+            Wynnrunner.error("Unable to determine task location for challenge #"
+                    + lootrunDataHandler.getLootrunData().getNextChallengeNumber());
         }
     }
 }

--- a/common/src/main/java/com/fischl/wynnrunner/mixin/LootrunModelMixin.java
+++ b/common/src/main/java/com/fischl/wynnrunner/mixin/LootrunModelMixin.java
@@ -192,7 +192,7 @@ public abstract class LootrunModelMixin extends Model {
         }
         // Sometimes the LootrunBeaconSelected event does not get fired
         // If we were to subscribe to this event in a method we could possibly miss out on both the beacon taken,
-        // and it's location.
+        // and its location.
         // This section is a workaround for the issue
         Beacon closestBeacon = getClosestBeacon();
         if (oldState == LootrunningState.CHOOSING_BEACON
@@ -202,7 +202,7 @@ public abstract class LootrunModelMixin extends Model {
             // Beacon taken should be fine here
             lootrunDataHandler.getCurrentChallenge().setBeaconTaken(color);
             // beacons may not contain an entry for the beacon color
-            var prediction = beacons.get(closestBeacon.beaconKind());
+            var prediction = beacons.get(color);
             if (prediction != null && prediction.taskLocation() != null) {
                 lootrunDataHandler.getCurrentChallenge().setLocation(prediction.taskLocation());
             } else {
@@ -235,11 +235,14 @@ public abstract class LootrunModelMixin extends Model {
     @Unique
     protected TaskLocation getBestTaskLocation(Vec3 playerPos, LootrunLocation location) {
         TaskLocation bestLocation = null;
+        double bestDistanceSq = Double.POSITIVE_INFINITY;
         for (TaskLocation loc : taskLocations.get(location)) {
-            if (bestLocation == null
-                    || getDistanceBetweenIgnoringY(playerPos, loc.location().toVec3())
-                            < getDistanceBetweenIgnoringY(
-                                    playerPos, bestLocation.location().toVec3())) {
+            Vec3 locPos = loc.location().toVec3();
+            double dx = playerPos.x - locPos.x;
+            double dz = playerPos.z - locPos.z;
+            double distanceSq = dx * dx + dz * dz;
+            if (bestLocation == null || distanceSq < bestDistanceSq) {
+                bestDistanceSq = distanceSq;
                 bestLocation = loc;
             }
         }
@@ -332,10 +335,5 @@ public abstract class LootrunModelMixin extends Model {
         } catch (Throwable t) {
             Wynnrunner.error("Error in lootrun tick poller: " + t);
         }
-    }
-
-    @Unique
-    public double getDistanceBetweenIgnoringY(Vec3 pos1, Vec3 pos2) {
-        return Math.sqrt(Math.pow(pos1.x - pos2.x, 2) + Math.pow(pos1.z - pos2.z, 2));
     }
 }

--- a/common/src/main/java/com/fischl/wynnrunner/mixin/LootrunModelMixin.java
+++ b/common/src/main/java/com/fischl/wynnrunner/mixin/LootrunModelMixin.java
@@ -19,7 +19,6 @@ import com.wynntils.mc.extension.EntityExtension;
 import com.wynntils.models.beacons.type.Beacon;
 import com.wynntils.models.lootrun.LootrunModel;
 import com.wynntils.models.lootrun.beacons.LootrunBeaconKind;
-import com.wynntils.models.lootrun.event.LootrunBeaconSelectedEvent;
 import com.wynntils.models.lootrun.type.LootrunLocation;
 import com.wynntils.models.lootrun.type.LootrunningState;
 import com.wynntils.models.lootrun.type.MissionType;
@@ -28,6 +27,7 @@ import com.wynntils.models.lootrun.type.TaskPrediction;
 import com.wynntils.models.lootrun.type.TrialType;
 import com.wynntils.models.worlds.event.WorldStateEvent;
 import com.wynntils.models.worlds.type.WorldState;
+import com.wynntils.utils.mc.McUtils;
 import com.wynntils.utils.mc.PosUtils;
 import com.wynntils.utils.type.CappedValue;
 import com.wynntils.utils.type.Pair;
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import net.minecraft.world.phys.Vec3;
 import net.neoforged.bus.api.SubscribeEvent;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -189,6 +190,60 @@ public abstract class LootrunModelMixin extends Model {
             lootrunDataHandler.save(false);
             return;
         }
+        // Sometimes the LootrunBeaconSelected event does not get fired
+        // If we were to subscribe to this event in a method we could possibly miss out on both the beacon taken,
+        // and it's location.
+        // This section is a workaround for the issue
+        Beacon closestBeacon = getClosestBeacon();
+        if (oldState == LootrunningState.CHOOSING_BEACON
+                && newState == LootrunningState.IN_TASK
+                && closestBeacon != null
+                && closestBeacon.beaconKind() instanceof LootrunBeaconKind color) {
+            // Beacon taken should be fine here
+            lootrunDataHandler.getCurrentChallenge().setBeaconTaken(color);
+            // beacons may not contain an entry for the beacon color
+            var prediction = beacons.get(closestBeacon.beaconKind());
+            if (prediction != null && prediction.taskLocation() != null) {
+                lootrunDataHandler.getCurrentChallenge().setLocation(prediction.taskLocation());
+            } else {
+                Wynnrunner.warn("Unable to determine task location for challenge #"
+                        + lootrunDataHandler.getLootrunData().getNextChallengeNumber()
+                        + " estimating based on position...");
+                Vec3 playerPos = McUtils.player().position();
+                if (lootrunDataHandler.getLootrunData().getLocation() == LootrunLocation.UNKNOWN) {
+                    Wynnrunner.error("Unable to determine lootrun location for challenge #"
+                            + lootrunDataHandler.getLootrunData().getNextChallengeNumber()
+                            + " unable to estimate task location");
+                    return;
+                }
+                TaskLocation bestLocation = getBestTaskLocation(
+                        playerPos, lootrunDataHandler.getLootrunData().getLocation());
+                if (bestLocation != null) {
+                    lootrunDataHandler.getCurrentChallenge().setLocation(bestLocation);
+                    Wynnrunner.info("Estimated task location for challenge #"
+                            + lootrunDataHandler.getLootrunData().getNextChallengeNumber()
+                            + " as " + bestLocation.name());
+                } else {
+                    Wynnrunner.error("Unable to determine task location for challenge #"
+                            + lootrunDataHandler.getLootrunData().getNextChallengeNumber()
+                            + " unable to estimate task location");
+                }
+            }
+        }
+    }
+
+    @Unique
+    protected TaskLocation getBestTaskLocation(Vec3 playerPos, LootrunLocation location) {
+        TaskLocation bestLocation = null;
+        for (TaskLocation loc : taskLocations.get(location)) {
+            if (bestLocation == null
+                    || getDistanceBetweenIgnoringY(playerPos, loc.location().toVec3())
+                            < getDistanceBetweenIgnoringY(
+                                    playerPos, bestLocation.location().toVec3())) {
+                bestLocation = loc;
+            }
+        }
+        return bestLocation;
     }
 
     @Inject(method = "challengeCompleted", at = @At("TAIL"))
@@ -280,17 +335,7 @@ public abstract class LootrunModelMixin extends Model {
     }
 
     @Unique
-    @SubscribeEvent
-    public void onLootrunBeaconSelected(LootrunBeaconSelectedEvent event) {
-        lootrunDataHandler
-                .getCurrentChallenge()
-                .setBeaconTaken(LootrunBeaconKind.fromColor(
-                        event.getBeacon().beaconKind().getCustomColor()));
-        if (event.getTaskLocation() != null) {
-            lootrunDataHandler.getCurrentChallenge().setLocation(event.getTaskLocation());
-        } else {
-            Wynnrunner.error("Unable to determine task location for challenge #"
-                    + lootrunDataHandler.getLootrunData().getNextChallengeNumber());
-        }
+    public double getDistanceBetweenIgnoringY(Vec3 pos1, Vec3 pos2) {
+        return Math.sqrt(Math.pow(pos1.x - pos2.x, 2) + Math.pow(pos1.z - pos2.z, 2));
     }
 }

--- a/common/src/main/java/com/fischl/wynnrunner/mixin/LootrunModelMixin.java
+++ b/common/src/main/java/com/fischl/wynnrunner/mixin/LootrunModelMixin.java
@@ -206,13 +206,14 @@ public abstract class LootrunModelMixin extends Model {
             if (prediction != null && prediction.taskLocation() != null) {
                 lootrunDataHandler.getCurrentChallenge().setLocation(prediction.taskLocation());
             } else {
+                int nextChallengeNumber = lootrunDataHandler.getLootrunData().getNextChallengeNumber();
                 Wynnrunner.warn("Unable to determine task location for challenge #"
-                        + lootrunDataHandler.getLootrunData().getNextChallengeNumber()
+                        + nextChallengeNumber
                         + " estimating based on position...");
                 Vec3 playerPos = McUtils.player().position();
                 if (lootrunDataHandler.getLootrunData().getLocation() == LootrunLocation.UNKNOWN) {
                     Wynnrunner.error("Unable to determine lootrun location for challenge #"
-                            + lootrunDataHandler.getLootrunData().getNextChallengeNumber()
+                            + nextChallengeNumber
                             + " unable to estimate task location");
                     return;
                 }
@@ -221,11 +222,11 @@ public abstract class LootrunModelMixin extends Model {
                 if (bestLocation != null) {
                     lootrunDataHandler.getCurrentChallenge().setLocation(bestLocation);
                     Wynnrunner.info("Estimated task location for challenge #"
-                            + lootrunDataHandler.getLootrunData().getNextChallengeNumber()
+                            + nextChallengeNumber
                             + " as " + bestLocation.name());
                 } else {
                     Wynnrunner.error("Unable to determine task location for challenge #"
-                            + lootrunDataHandler.getLootrunData().getNextChallengeNumber()
+                            + nextChallengeNumber
                             + " unable to estimate task location");
                 }
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ neoforge_version=21.11.38-beta
 # Note: Must use same version of eventbus as is used in the above forge version!
 neoforge_eventbus_version=8.0.5
 # Update this when wynntils has an update
-wynntils_version = 4.0.4
+wynntils_version = 4.0.10
 # Dev Tools
 spotless_version = 8.2.1
 spotless_palantir_version = 2.87.0


### PR DESCRIPTION
Originally intended to rely on Wynntils' `LootrunBeaconSelected` event - however this does not always fire due to what I think is a bug in Wynntils code. 

To get around this, I have added some logic to the `handleStateChange()` mixin that estimates the selected task based on the list of known task positions (provided by Wynntils) and the player's current position (ignoring the Y coordinate).